### PR TITLE
Add URL to share text

### DIFF
--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -13,7 +13,7 @@ export const shareStatus = (guesses: string[][], lost: boolean) => {
       '\n\n' +
       generateEmojiGrid(guesses) +
       '\n\n' +
-      window.location.href
+      window.location.href.replace(`${window.location.protocol}//`, '')
   )
 }
 

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -11,7 +11,9 @@ export const shareStatus = (guesses: string[][], lost: boolean) => {
       '/' +
       CONFIG.tries.toString() +
       '\n\n' +
-      generateEmojiGrid(guesses)
+      generateEmojiGrid(guesses) +
+      '\n\n' +
+      window.location.href
   )
 }
 


### PR DESCRIPTION
Add the current URL at the end of the share text, so recipients know where to play.

(Thank you for making this! I had fun implementing [with Vietnamese](https://victorl.in/vordle/) and it was easy to use.)